### PR TITLE
(#34) 🔀 :: Email Sender 패키지 경로 변경 및 SecurityConfig 경로 허용

### DIFF
--- a/src/main/java/com/example/bugle_be/domain/mail/service/MailService.java
+++ b/src/main/java/com/example/bugle_be/domain/mail/service/MailService.java
@@ -8,7 +8,7 @@ import com.example.bugle_be.domain.mail.exception.HashingFailed;
 import com.example.bugle_be.domain.mail.presentation.dto.request.SendCodeRequest;
 import com.example.bugle_be.domain.mail.presentation.dto.request.VerifyCodeRequest;
 import com.example.bugle_be.domain.mail.service.properties.MailProperties;
-import com.example.bugle_be.global.mail.service.MailSenderService;
+import com.example.bugle_be.infra.mail.service.MailSenderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/example/bugle_be/domain/mail/service/MailService.java
+++ b/src/main/java/com/example/bugle_be/domain/mail/service/MailService.java
@@ -8,7 +8,7 @@ import com.example.bugle_be.domain.mail.exception.HashingFailed;
 import com.example.bugle_be.domain.mail.presentation.dto.request.SendCodeRequest;
 import com.example.bugle_be.domain.mail.presentation.dto.request.VerifyCodeRequest;
 import com.example.bugle_be.domain.mail.service.properties.MailProperties;
-import com.example.bugle_be.infra.mail.service.MailSenderService;
+import com.example.bugle_be.infra.mail.MailSenderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/example/bugle_be/global/security/SecurityConfig.java
+++ b/src/main/java/com/example/bugle_be/global/security/SecurityConfig.java
@@ -35,9 +35,14 @@ public class SecurityConfig {
             .formLogin(AbstractHttpConfigurer::disable)
             .sessionManagement(configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(authorizeRequests -> authorizeRequests
+                // auth
                 .requestMatchers(HttpMethod.POST,"/auth/login").permitAll()
                 .requestMatchers(HttpMethod.POST, "/auth/signup").permitAll()
                 .requestMatchers(HttpMethod.POST, "/auth/reissue").permitAll()
+
+                // mail
+                .requestMatchers(HttpMethod.POST, "/mail/send").permitAll()
+                .requestMatchers(HttpMethod.POST, "/mail/verify").permitAll()
                 .anyRequest().authenticated())
             .addFilterBefore(new JwtFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
             .addFilterBefore(new GlobalExceptionFilter(objectMapper), JwtFilter.class)

--- a/src/main/java/com/example/bugle_be/infra/mail/MailSenderService.java
+++ b/src/main/java/com/example/bugle_be/infra/mail/MailSenderService.java
@@ -1,4 +1,4 @@
-package com.example.bugle_be.infra.mail.service;
+package com.example.bugle_be.infra.mail;
 
 import com.example.bugle_be.domain.mail.exception.MailSendFailed;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/bugle_be/infra/mail/service/MailSenderService.java
+++ b/src/main/java/com/example/bugle_be/infra/mail/service/MailSenderService.java
@@ -1,4 +1,4 @@
-package com.example.bugle_be.global.mail.service;
+package com.example.bugle_be.infra.mail.service;
 
 import com.example.bugle_be.domain.mail.exception.MailSendFailed;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
## ✨ 어떤 PR인가요?

> 패키지 경로 변경 및 미인증 경로 허용

## 📌 관련 이슈

> 관련된 이슈 번호를 연결해주세요  
- #34 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 메일 전송 및 인증 요청을 인증 없이 이용할 수 있도록 공개 엔드포인트 추가(/mail/send, /mail/verify).
  - 기존 /auth 경로의 접근 정책은 동일하며, 그 외 엔드포인트는 계속 인증이 필요합니다.

- Refactor
  - 메일 발송 관련 모듈 구조를 재정비했습니다. 기능, 동작, 외부 API에는 변화가 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->