### PR TITLE
(#44) 🔀 :: 회원 기본 이미지 및 DTO 정규식/메시지 상수화

### DIFF
--- a/src/main/java/com/example/bugle_be/domain/auth/presentation/dto/request/LoginRequest.java
+++ b/src/main/java/com/example/bugle_be/domain/auth/presentation/dto/request/LoginRequest.java
@@ -1,27 +1,29 @@
 package com.example.bugle_be.domain.auth.presentation.dto.request;
 
+import com.example.bugle_be.global.util.MessageProperty;
+import com.example.bugle_be.global.util.RegexProperty;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record LoginRequest(
-    @Email(message = "올바른 형식의 이메일을 입력해주세요.")
+    @Email(message = MessageProperty.EMAIL_INVALID)
     String email,
 
     @Pattern(
-        regexp = "^(?!\\.)([a-z0-9._]{4,20})(?<!\\.)$",
-        message = "아이디는 소문자, 숫자, 언더바(_), 점(.)만 사용 가능하며, 시작과 끝은 점(.)일 수 없습니다."
+        regexp = RegexProperty.ACCOUNT_ID,
+        message = MessageProperty.ACCOUNT_ID_PATTERN
     )
-    @Size(min = 4, max = 20, message = "아이디는 최소 4자 이상, 20자 이하로 입력해주세요.")
+    @Size(min = 4, max = 20, message = MessageProperty.ACCOUNT_ID_SIZE)
     String accountId,
 
     @Pattern(
-        regexp = "^(?=.*[@#!%&*])[a-zA-Z0-9@#!%&*]+$",
-        message = "비밀번호는 영어 대소문자, 숫자만 허용되며 @, #, !, %, &, * 중 하나 이상을 포함해야 합니다."
+        regexp = RegexProperty.PASSWORD,
+        message = MessageProperty.PASSWORD_PATTERN
     )
-    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
-    @Size(min = 8, max = 30, message = "비밀번호는 최소 8자 이상, 30자 이하로 입력해주세요.")
+    @NotBlank(message = MessageProperty.PASSWORD_NOT_BLANK)
+    @Size(min = 8, max = 30, message = MessageProperty.PASSWORD_SIZE)
     String password
 ) {
 }

--- a/src/main/java/com/example/bugle_be/domain/auth/presentation/dto/request/PasswordResetRequest.java
+++ b/src/main/java/com/example/bugle_be/domain/auth/presentation/dto/request/PasswordResetRequest.java
@@ -1,24 +1,26 @@
 package com.example.bugle_be.domain.auth.presentation.dto.request;
 
+import com.example.bugle_be.global.util.MessageProperty;
+import com.example.bugle_be.global.util.RegexProperty;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record PasswordResetRequest(
-    @Email(message = "올바른 형식의 이메일을 입력해주세요.")
-    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+    @Email(message = MessageProperty.EMAIL_INVALID)
+    @NotBlank(message = MessageProperty.EMAIL_NOT_BLANK)
     String email,
 
-    @NotBlank(message = "토큰은 필수 입력 항목입니다.")
+    @NotBlank(message = MessageProperty.TOKEN_NOT_BLANK)
     String token,
 
     @Pattern(
-        regexp = "^(?=.*[@#!%&*])[a-zA-Z0-9@#!%&*]+$",
-        message = "비밀번호는 영어 대소문자, 숫자만 허용되며 @, #, !, %, &, * 중 하나 이상을 포함해야 합니다."
+        regexp = RegexProperty.PASSWORD,
+        message = MessageProperty.PASSWORD_PATTERN
     )
-    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
-    @Size(min = 8, max = 30, message = "비밀번호는 최소 8자 이상, 30자 이하로 입력해주세요.")
+    @NotBlank(message = MessageProperty.PASSWORD_NOT_BLANK)
+    @Size(min = 8, max = 30, message = MessageProperty.PASSWORD_SIZE)
     String newPassword
 ) {
 }

--- a/src/main/java/com/example/bugle_be/domain/auth/presentation/dto/request/SignupRequest.java
+++ b/src/main/java/com/example/bugle_be/domain/auth/presentation/dto/request/SignupRequest.java
@@ -1,35 +1,38 @@
 package com.example.bugle_be.domain.auth.presentation.dto.request;
 
+import com.example.bugle_be.global.util.MessageProperty;
+import com.example.bugle_be.global.util.RegexProperty;
 import jakarta.validation.constraints.*;
 
 public record SignupRequest(
-    @Email(message = "올바른 형식의 이메일을 입력해주세요.")
-    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+    @Email(message = MessageProperty.EMAIL_INVALID)
+    @NotBlank(message = MessageProperty.EMAIL_NOT_BLANK)
     String email,
 
+    @NotBlank(message = MessageProperty.TOKEN_NOT_BLANK)
     String token,
 
     @Pattern(
-        regexp = "^(?=.*[@#!%&*])[a-zA-Z0-9@#!%&*]+$",
-        message = "비밀번호는 영어 대소문자, 숫자만 허용되며 @, #, !, %, &, * 중 하나 이상을 포함해야 합니다."
+        regexp = RegexProperty.PASSWORD,
+        message = MessageProperty.PASSWORD_PATTERN
     )
-    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
-    @Size(min = 8, max = 30, message = "비밀번호는 최소 8자 이상, 30자 이하로 입력해주세요.")
+    @NotBlank(message = MessageProperty.PASSWORD_NOT_BLANK)
+    @Size(min = 8, max = 30, message = MessageProperty.PASSWORD_SIZE)
     String password,
 
     @Pattern(
-        regexp = "^(?!\\.)([a-z0-9._]{4,20})(?<!\\.)$",
-        message = "아이디는 소문자, 숫자, 언더바(_), 점(.)만 사용 가능하며, 시작과 끝은 점(.)일 수 없습니다."
+        regexp = RegexProperty.ACCOUNT_ID,
+        message = MessageProperty.ACCOUNT_ID_PATTERN
     )
-    @NotBlank(message = "아이디는 필수 입력 항목입니다.")
-    @Size(min = 4, max = 20, message = "아이디는 최소 4자 이상, 20자 이하로 입력해주세요.")
+    @NotBlank(message = MessageProperty.ACCOUNT_ID_NOT_BLANK)
+    @Size(min = 4, max = 20, message = MessageProperty.ACCOUNT_ID_SIZE)
     String accountId,
 
     @Pattern(
-        regexp = "^[a-zA-Z가-힣]+$",
-        message = "이름은 한글 또는 영어 대소문자만 입력 가능합니다."
+        regexp = RegexProperty.USERNAME,
+        message = MessageProperty.USERNAME_PATTERN
     )
-    @Size(max = 20, message = "이름은 20자 이내로 입력해주세요.")
+    @Size(max = 20, message = MessageProperty.USERNAME_SIZE)
     String userName
 ) {
 }

--- a/src/main/java/com/example/bugle_be/domain/auth/service/SignupService.java
+++ b/src/main/java/com/example/bugle_be/domain/auth/service/SignupService.java
@@ -7,7 +7,6 @@ import com.example.bugle_be.domain.auth.presentation.dto.response.TokenResponse;
 import com.example.bugle_be.domain.mail.service.MailService;
 import com.example.bugle_be.domain.user.domain.User;
 import com.example.bugle_be.domain.user.domain.repository.UserRepository;
-import com.example.bugle_be.domain.user.profile.DefaultImageProperties;
 import com.example.bugle_be.global.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -21,7 +20,6 @@ public class SignupService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
-    private final DefaultImageProperties defaultImage;
     private final MailService mailService;
 
     @Transactional
@@ -50,7 +48,6 @@ public class SignupService {
                 .password(passwordEncoder.encode(request.password()))
                 .accountId(request.accountId())
                 .userName(request.userName())
-                .profileImageUrl(defaultImage.defaultImageUrl())
                 .build()
         );
     }

--- a/src/main/java/com/example/bugle_be/domain/user/domain/User.java
+++ b/src/main/java/com/example/bugle_be/domain/user/domain/User.java
@@ -1,9 +1,11 @@
 package com.example.bugle_be.domain.user.domain;
 
 import com.example.bugle_be.global.entity.BaseTimeEntity;
+import com.example.bugle_be.global.util.ImageProperty;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @Builder
@@ -24,6 +26,7 @@ public class User extends BaseTimeEntity {
     @Column(columnDefinition = "VARCHAR(20)")
     private String userName;
 
+    @ColumnDefault(ImageProperty.DEFAULT_USER_PROFILE_IMAGE)
     @Column(nullable = false, columnDefinition = "VARCHAR(255)")
     private String profileImageUrl;
 

--- a/src/main/java/com/example/bugle_be/domain/user/profile/DefaultImageProperties.java
+++ b/src/main/java/com/example/bugle_be/domain/user/profile/DefaultImageProperties.java
@@ -1,9 +1,0 @@
-package com.example.bugle_be.domain.user.profile;
-
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
-@ConfigurationProperties(prefix = "user.profile")
-public record DefaultImageProperties(
-    String defaultImageUrl
-) {
-}

--- a/src/main/java/com/example/bugle_be/global/util/ImageProperty.java
+++ b/src/main/java/com/example/bugle_be/global/util/ImageProperty.java
@@ -1,0 +1,9 @@
+package com.example.bugle_be.global.util;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class ImageProperty {
+
+    public static final String DEFAULT_USER_PROFILE_IMAGE = "default_user.png";
+}

--- a/src/main/java/com/example/bugle_be/global/util/MessageProperty.java
+++ b/src/main/java/com/example/bugle_be/global/util/MessageProperty.java
@@ -1,0 +1,28 @@
+package com.example.bugle_be.global.util;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class MessageProperty {
+
+    // email
+    public static final String EMAIL_INVALID = "올바른 형식의 이메일을 입력해주세요.";
+    public static final String EMAIL_NOT_BLANK = "이메일은 필수 입력 항목입니다.";
+
+    // accountId
+    public static final String ACCOUNT_ID_PATTERN = "아이디는 소문자, 숫자, 언더바(_), 점(.)만 사용 가능하며, 시작과 끝은 점(.)일 수 없습니다.";
+    public static final String ACCOUNT_ID_NOT_BLANK = "아이디는 필수 입력 항목입니다.";
+    public static final String ACCOUNT_ID_SIZE = "아이디는 최소 4자 이상, 20자 이하로 입력해주세요.";
+
+    // password
+    public static final String PASSWORD_PATTERN = "비밀번호는 영어 대소문자, 숫자만 허용되며 @, #, !, %, &, * 중 하나 이상을 포함해야 합니다.";
+    public static final String PASSWORD_NOT_BLANK = "비밀번호는 필수 입력 항목입니다.";
+    public static final String PASSWORD_SIZE = "비밀번호는 최소 8자 이상, 30자 이하로 입력해주세요.";
+
+    // userName
+    public static final String USERNAME_PATTERN = "이름은 한글 또는 영어 대소문자만 입력 가능합니다.";
+    public static final String USERNAME_SIZE = "이름은 20자 이내로 입력해주세요.";
+
+    // token
+    public static final String TOKEN_NOT_BLANK = "인증 토큰은 필수 입력 항목입니다.";
+}

--- a/src/main/java/com/example/bugle_be/global/util/RegexProperty.java
+++ b/src/main/java/com/example/bugle_be/global/util/RegexProperty.java
@@ -1,0 +1,13 @@
+package com.example.bugle_be.global.util;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class RegexProperty {
+
+    public static final String PASSWORD = "^(?=.*[@#!%&*])[a-zA-Z0-9@#!%&*]+$";
+
+    public static final String ACCOUNT_ID = "^(?!\\.)([a-z0-9._]{4,20})(?<!\\.)$";
+
+    public static final String USERNAME = "^[a-zA-Z가-힣]+$";
+}

--- a/src/main/java/com/example/bugle_be/infra/oauth/info/Oauth2UserInfo.java
+++ b/src/main/java/com/example/bugle_be/infra/oauth/info/Oauth2UserInfo.java
@@ -8,7 +8,5 @@ public interface Oauth2UserInfo {
 
     String getAccountId();
 
-    String getProfileImageUrl();
-
     Oauth2Provider getOauth2Provider();
 }

--- a/src/main/java/com/example/bugle_be/infra/oauth/info/kakao/KakaoOauth2UserInfo.java
+++ b/src/main/java/com/example/bugle_be/infra/oauth/info/kakao/KakaoOauth2UserInfo.java
@@ -13,7 +13,6 @@ public class KakaoOauth2UserInfo implements Oauth2UserInfo {
 
     private final String email;
     private final String accountId;
-    private final String profileImageUrl;
 
     public KakaoOauth2UserInfo(Map<String, Object> attributes) {
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
@@ -35,8 +34,6 @@ public class KakaoOauth2UserInfo implements Oauth2UserInfo {
         if (accountId == null) {
             throw OauthAccountIdNotFound.EXCEPTION;
         }
-
-        this.profileImageUrl = (String) kakaoProfile.get("profile_image_url");
     }
 
     @Override
@@ -47,11 +44,6 @@ public class KakaoOauth2UserInfo implements Oauth2UserInfo {
     @Override
     public String getAccountId() {
         return accountId;
-    }
-
-    @Override
-    public String getProfileImageUrl() {
-        return profileImageUrl;
     }
 
     @Override

--- a/src/main/java/com/example/bugle_be/infra/oauth/service/CustomOauth2UserService.java
+++ b/src/main/java/com/example/bugle_be/infra/oauth/service/CustomOauth2UserService.java
@@ -50,7 +50,6 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
                 User newUser = User.builder()
                     .email(userInfo.getEmail())
                     .accountId(userInfo.getAccountId())
-                    .profileImageUrl(userInfo.getProfileImageUrl())
                     .build();
                 return userRepository.save(newUser);
             });

--- a/src/main/resources/db/migration/V3__modify_user_profile_image_add_default.sql
+++ b/src/main/resources/db/migration/V3__modify_user_profile_image_add_default.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tbl_user
+    MODIFY COLUMN profile_image_url VARCHAR(255) NOT NULL DEFAULT 'default_user.png';


### PR DESCRIPTION
## ✨ 어떤 PR인가요?

- 회원 기본 이미지를 상수화하여 설정하고, 기존 회원 저장 시 사용되던 프로필 이미지 관련 코드를 제거했습니다.
- DTO 정규식 및 메시지를 상수화하여 재사용성 및 유지보수성을 높였습니다.
- 유저 엔티티의 profileImageUrl 컬럼의 기본값을 설정하고 해당 마이그레이션 스크립트를 작성하였습니다.


## 📌 관련 이슈

> 관련된 이슈 번호를 연결해주세요  
- #44 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 프로필 이미지를 설정하지 않아도 기본 프로필 이미지가 자동 적용됩니다(소셜 로그인 포함).
- Refactor
  - 회원가입/로그인/비밀번호 재설정의 입력 유효성 검증 메시지를 중앙화하여 문구를 일관되고 이해하기 쉽게 개선했습니다.
  - 이메일, 아이디, 비밀번호, 이름, 토큰의 형식·패턴·길이 제한 안내가 더 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->