### PR TITLE
(#73) 🔀 :: S3 인증 방식을 IAM Role 기반 구조로 변경

### DIFF
--- a/src/main/java/com/example/bugle_be/infra/s3/config/S3Config.java
+++ b/src/main/java/com/example/bugle_be/infra/s3/config/S3Config.java
@@ -4,8 +4,6 @@ import com.example.bugle_be.infra.s3.properties.S3Properties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
@@ -17,26 +15,16 @@ public class S3Config {
     private final S3Properties s3Properties;
 
     @Bean
-    public AwsBasicCredentials awsBasicCredentials() {
-        return AwsBasicCredentials.create(
-            s3Properties.accessKey(),
-            s3Properties.secretKey()
-        );
-    }
-
-    @Bean
-    public S3Presigner s3Presigner(AwsBasicCredentials awsBasicCredentials) {
+    public S3Presigner s3Presigner() {
         return S3Presigner.builder()
             .region(Region.of(s3Properties.region()))
-            .credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials))
             .build();
     }
 
     @Bean
-    public S3Client s3Client(AwsBasicCredentials awsBasicCredentials) {
+    public S3Client s3Client() {
         return S3Client.builder()
             .region(Region.of(s3Properties.region()))
-            .credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials))
             .build();
     }
 }

--- a/src/main/java/com/example/bugle_be/infra/s3/properties/S3Properties.java
+++ b/src/main/java/com/example/bugle_be/infra/s3/properties/S3Properties.java
@@ -5,8 +5,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "cloud.aws")
 public record S3Properties(
     String bucket,
-    String accessKey,
-    String secretKey,
     String region
 ) {
 }


### PR DESCRIPTION
## ✨ 어떤 PR인가요?

> 이 PR이 어떤 작업을 하는지 간단하게 설명해주세요!  
- 기존에 환경변수 설정을 통해 S3 키를 직접 등록하던 방식에서 IAM Role 기반 구조로 인증 방식 변경


## 📌 관련 이슈

> 관련된 이슈 번호를 연결해주세요  
- #73 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * AWS 자격증명 설정 프로세스가 간소화되었습니다.
  * AWS SDK의 기본 자격증명 해석 메커니즘을 사용하도록 변경하여 설정 복잡성을 감소시켰습니다.
  * 민감한 자격증명 정보 노출이 최소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->