### PR TITLE
(#84) 🔀 :: S3 파일 삭제 API

### DIFF
--- a/src/main/java/com/example/bugle_be/domain/auth/service/WithdrawService.java
+++ b/src/main/java/com/example/bugle_be/domain/auth/service/WithdrawService.java
@@ -4,8 +4,9 @@ import com.example.bugle_be.domain.auth.domain.repository.RefreshTokenRepository
 import com.example.bugle_be.domain.user.domain.User;
 import com.example.bugle_be.domain.user.domain.repository.UserRepository;
 import com.example.bugle_be.domain.user.facade.UserFacade;
-import com.example.bugle_be.infra.s3.service.S3Service;
+import com.example.bugle_be.infra.s3.event.S3DeleteEvent;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,18 +18,18 @@ public class WithdrawService {
     private final UserFacade userFacade;
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
-    private final S3Service s3Service;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public void execute() {
         User user = userFacade.getCurrentUser();
 
-        if (user.isCustomProfileImage()) {
-            s3Service.deleteObject(user.getProfileImageObjectKey());
-        }
-
         refreshTokenRepository.deleteById(user.getEmail());
         userRepository.delete(user);
+
+        if (user.isCustomProfileImage()) {
+            eventPublisher.publishEvent(new S3DeleteEvent(user.getProfileImageObjectKey()));
+        }
 
         SecurityContextHolder.clearContext();
     }

--- a/src/main/java/com/example/bugle_be/domain/auth/service/WithdrawService.java
+++ b/src/main/java/com/example/bugle_be/domain/auth/service/WithdrawService.java
@@ -4,6 +4,7 @@ import com.example.bugle_be.domain.auth.domain.repository.RefreshTokenRepository
 import com.example.bugle_be.domain.user.domain.User;
 import com.example.bugle_be.domain.user.domain.repository.UserRepository;
 import com.example.bugle_be.domain.user.facade.UserFacade;
+import com.example.bugle_be.infra.s3.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -16,10 +17,15 @@ public class WithdrawService {
     private final UserFacade userFacade;
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final S3Service s3Service;
 
     @Transactional
     public void execute() {
         User user = userFacade.getCurrentUser();
+
+        if (user.isCustomProfileImage()) {
+            s3Service.deleteObject(user.getProfileImageObjectKey());
+        }
 
         refreshTokenRepository.deleteById(user.getEmail());
         userRepository.delete(user);

--- a/src/main/java/com/example/bugle_be/domain/comment/domain/repository/CommentRepositoryCustomImpl.java
+++ b/src/main/java/com/example/bugle_be/domain/comment/domain/repository/CommentRepositoryCustomImpl.java
@@ -29,7 +29,7 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
                     new QCommentsResponse_CommentDto_UserDto(
                         comment.user.id,
                         comment.user.accountId,
-                        comment.user.profileImageUrl
+                        comment.user.profileImageObjectKey
                     )
                 )
             )

--- a/src/main/java/com/example/bugle_be/domain/comment/presentation/dto/response/CommentsResponse.java
+++ b/src/main/java/com/example/bugle_be/domain/comment/presentation/dto/response/CommentsResponse.java
@@ -18,7 +18,7 @@ public record CommentsResponse(
         public record UserDto(
             Long id,
             String accountId,
-            String profileImageUrl
+            String profileImageObjectKey
         ) {
             @QueryProjection
             public UserDto {

--- a/src/main/java/com/example/bugle_be/domain/follow/domain/repository/FollowRepositoryCustomImpl.java
+++ b/src/main/java/com/example/bugle_be/domain/follow/domain/repository/FollowRepositoryCustomImpl.java
@@ -29,7 +29,7 @@ public class FollowRepositoryCustomImpl implements FollowRepositoryCustom {
                     user.id,
                     user.accountId,
                     user.userName,
-                    user.profileImageUrl
+                    user.profileImageObjectKey
                 )
             )
             .from(follow)
@@ -60,7 +60,7 @@ public class FollowRepositoryCustomImpl implements FollowRepositoryCustom {
                     user.id,
                     user.accountId,
                     user.userName,
-                    user.profileImageUrl
+                    user.profileImageObjectKey
                 )
             )
             .from(follow)

--- a/src/main/java/com/example/bugle_be/domain/follow/presentation/dto/response/FollowResponse.java
+++ b/src/main/java/com/example/bugle_be/domain/follow/presentation/dto/response/FollowResponse.java
@@ -11,7 +11,7 @@ public record FollowResponse(
         Long userId,
         String accountId,
         String userName,
-        String profileImageUrl
+        String profileImageObjectKey
     ) {
         @QueryProjection
         public UserDto {

--- a/src/main/java/com/example/bugle_be/domain/post/domain/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/example/bugle_be/domain/post/domain/repository/PostRepositoryCustomImpl.java
@@ -30,7 +30,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
                 new QPostsResponse_PostPreviewResponse(
                     post.id,
                     post.user.accountId,
-                    post.user.profileImageUrl,
+                    post.user.profileImageObjectKey,
                     post.country,
                     post.region,
                     post.objectKey,

--- a/src/main/java/com/example/bugle_be/domain/post/presentation/dto/response/PostsResponse.java
+++ b/src/main/java/com/example/bugle_be/domain/post/presentation/dto/response/PostsResponse.java
@@ -10,7 +10,7 @@ public record PostsResponse(
     public record PostPreviewResponse(
         Long id,
         String accountId,
-        String profileImageUrl,
+        String profileImageObjectKey,
         String country,
         String region,
         String objectKey,

--- a/src/main/java/com/example/bugle_be/domain/post/service/DeletePostService.java
+++ b/src/main/java/com/example/bugle_be/domain/post/service/DeletePostService.java
@@ -6,6 +6,7 @@ import com.example.bugle_be.domain.post.exception.CannotDeletePost;
 import com.example.bugle_be.domain.post.facade.PostFacade;
 import com.example.bugle_be.domain.user.domain.User;
 import com.example.bugle_be.domain.user.facade.UserFacade;
+import com.example.bugle_be.infra.s3.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +18,7 @@ public class DeletePostService {
     private final UserFacade userFacade;
     private final PostFacade postFacade;
     private final PostRepository postRepository;
+    private final S3Service s3Service;
 
     @Transactional
     public void execute(Long postId) {
@@ -27,6 +29,7 @@ public class DeletePostService {
             throw CannotDeletePost.EXCEPTION;
         }
 
+        s3Service.deleteObject(post.getObjectKey());
         postRepository.delete(post);
     }
 }

--- a/src/main/java/com/example/bugle_be/domain/post/service/DeletePostService.java
+++ b/src/main/java/com/example/bugle_be/domain/post/service/DeletePostService.java
@@ -6,8 +6,9 @@ import com.example.bugle_be.domain.post.exception.CannotDeletePost;
 import com.example.bugle_be.domain.post.facade.PostFacade;
 import com.example.bugle_be.domain.user.domain.User;
 import com.example.bugle_be.domain.user.facade.UserFacade;
-import com.example.bugle_be.infra.s3.service.S3Service;
+import com.example.bugle_be.infra.s3.event.S3DeleteEvent;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,7 +19,7 @@ public class DeletePostService {
     private final UserFacade userFacade;
     private final PostFacade postFacade;
     private final PostRepository postRepository;
-    private final S3Service s3Service;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public void execute(Long postId) {
@@ -29,7 +30,7 @@ public class DeletePostService {
             throw CannotDeletePost.EXCEPTION;
         }
 
-        s3Service.deleteObject(post.getObjectKey());
         postRepository.delete(post);
+        eventPublisher.publishEvent(new S3DeleteEvent(post.getObjectKey()));
     }
 }

--- a/src/main/java/com/example/bugle_be/domain/search/presentation/dto/response/UserSearchResponse.java
+++ b/src/main/java/com/example/bugle_be/domain/search/presentation/dto/response/UserSearchResponse.java
@@ -11,7 +11,7 @@ public record UserSearchResponse(
         Long id,
         String accountId,
         String userName,
-        String profileImageUrl
+        String profileImageObjectKey
     ) {
         @QueryProjection
         public UserResponse {

--- a/src/main/java/com/example/bugle_be/domain/user/domain/User.java
+++ b/src/main/java/com/example/bugle_be/domain/user/domain/User.java
@@ -34,7 +34,7 @@ public class User extends BaseTimeEntity {
 
     @Builder.Default
     @Column(nullable = false, columnDefinition = "VARCHAR(255)")
-    private String profileImageUrl = ImageProperty.DEFAULT_USER_PROFILE_IMAGE;
+    private String profileImageObjectKey = ImageProperty.DEFAULT_USER_PROFILE_IMAGE;
 
     public void changePassword(String password) {
         this.password = password;
@@ -46,5 +46,9 @@ public class User extends BaseTimeEntity {
 
     public void deleteDeviceToken() {
         this.deviceToken = null;
+    }
+
+    public boolean isCustomProfileImage() {
+        return !this.profileImageObjectKey.equals(ImageProperty.DEFAULT_USER_PROFILE_IMAGE);
     }
 }

--- a/src/main/java/com/example/bugle_be/domain/user/domain/repository/UserRepositoryCustomImpl.java
+++ b/src/main/java/com/example/bugle_be/domain/user/domain/repository/UserRepositoryCustomImpl.java
@@ -26,7 +26,7 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
                 user.id,
                 user.accountId,
                 user.userName,
-                user.profileImageUrl
+                user.profileImageObjectKey
             ))
             .from(user)
             .where(user.accountId.containsIgnoreCase(keyword)

--- a/src/main/java/com/example/bugle_be/infra/s3/event/S3DeleteEvent.java
+++ b/src/main/java/com/example/bugle_be/infra/s3/event/S3DeleteEvent.java
@@ -1,0 +1,4 @@
+package com.example.bugle_be.infra.s3.event;
+
+public record S3DeleteEvent(String objectKey) {
+}

--- a/src/main/java/com/example/bugle_be/infra/s3/event/S3EventListener.java
+++ b/src/main/java/com/example/bugle_be/infra/s3/event/S3EventListener.java
@@ -1,0 +1,21 @@
+package com.example.bugle_be.infra.s3.event;
+
+import com.example.bugle_be.infra.s3.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3EventListener {
+
+    private final S3Service s3Service;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(S3DeleteEvent event) {
+        s3Service.deleteObject(event.objectKey());
+    }
+}

--- a/src/main/java/com/example/bugle_be/infra/s3/service/S3Service.java
+++ b/src/main/java/com/example/bugle_be/infra/s3/service/S3Service.java
@@ -37,6 +37,11 @@ public class S3Service {
     }
 
     public void deleteObject(String objectKey) {
+        if (objectKey == null || objectKey.isBlank()) {
+            log.warn("S3 삭제 실패 - objectKey가 null이거나 빈 문자열");
+            return;
+        }
+
         try {
             DeleteObjectRequest request = DeleteObjectRequest.builder()
                 .bucket(s3Properties.bucket())

--- a/src/main/java/com/example/bugle_be/infra/s3/service/S3Service.java
+++ b/src/main/java/com/example/bugle_be/infra/s3/service/S3Service.java
@@ -2,6 +2,7 @@ package com.example.bugle_be.infra.s3.service;
 
 import com.example.bugle_be.infra.s3.properties.S3Properties;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
@@ -12,6 +13,7 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
 import java.net.URL;
 import java.time.Duration;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class S3Service {
@@ -35,11 +37,15 @@ public class S3Service {
     }
 
     public void deleteObject(String objectKey) {
-        DeleteObjectRequest request = DeleteObjectRequest.builder()
-            .bucket(s3Properties.bucket())
-            .key(objectKey)
-            .build();
+        try {
+            DeleteObjectRequest request = DeleteObjectRequest.builder()
+                .bucket(s3Properties.bucket())
+                .key(objectKey)
+                .build();
 
-        s3Client.deleteObject(request);
+            s3Client.deleteObject(request);
+        } catch (Exception e) {
+            log.error("S3 삭제 실패 - key: {}", objectKey, e);
+        }
     }
 }

--- a/src/main/java/com/example/bugle_be/infra/s3/service/S3Service.java
+++ b/src/main/java/com/example/bugle_be/infra/s3/service/S3Service.java
@@ -3,6 +3,8 @@ package com.example.bugle_be.infra.s3.service;
 import com.example.bugle_be.infra.s3.properties.S3Properties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
@@ -14,8 +16,9 @@ import java.time.Duration;
 @RequiredArgsConstructor
 public class S3Service {
 
-    private final S3Presigner s3Presigner;
+    private final S3Client s3Client;
     private final S3Properties s3Properties;
+    private final S3Presigner s3Presigner;
 
     public URL createUploadPresignedUrl(String objectKey, Duration expiration) {
         PutObjectRequest request = PutObjectRequest.builder()
@@ -29,5 +32,14 @@ public class S3Service {
             .build();
 
         return s3Presigner.presignPutObject(presignedRequest).url();
+    }
+
+    public void deleteObject(String objectKey) {
+        DeleteObjectRequest request = DeleteObjectRequest.builder()
+            .bucket(s3Properties.bucket())
+            .key(objectKey)
+            .build();
+
+        s3Client.deleteObject(request);
     }
 }

--- a/src/main/resources/db/migration/V12__rename_profile_image_url_to_object_key.sql
+++ b/src/main/resources/db/migration/V12__rename_profile_image_url_to_object_key.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tbl_user
+    CHANGE profile_image_url profile_image_object_key VARCHAR(255)
+    NOT NULL DEFAULT 'default_user.png';


### PR DESCRIPTION
## 📌 관련 이슈

> 관련된 이슈 번호를 연결해주세요  
- #84 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 계정 삭제 및 게시물 삭제 시 업로드된 이미지가 S3에서 자동으로 정리됩니다(트랜잭션 커밋 후 비동기 삭제 처리).

* **개선 사항**
  * 사용자 및 게시물 관련 API의 프로필 이미지 참조가 일관된 형식(오브젝트 키)으로 변경되어 응답 및 이미지 관리 일관성이 향상되었습니다.

* **데이터 마이그레이션**
  * 이미지 참조 필드명 변경을 반영하는 데이터베이스 마이그레이션이 포함되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->