### PR TITLE
(#102) 🔀 :: 지역 정보 필드를 country/region에서 location으로 통합

### DIFF
--- a/src/main/java/com/example/bugle_be/domain/post/domain/Post.java
+++ b/src/main/java/com/example/bugle_be/domain/post/domain/Post.java
@@ -23,11 +23,8 @@ public class Post extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "VARCHAR(300)")
     private String content;
 
-    @Column(columnDefinition = "VARCHAR(20)")
-    private String country;
-
-    @Column(columnDefinition = "VARCHAR(20)")
-    private String region;
+    @Column(columnDefinition = "VARCHAR(150)")
+    private String location;
 
     @Column(nullable = false, columnDefinition = "VARCHAR(255)")
     private String objectKey;
@@ -36,10 +33,9 @@ public class Post extends BaseTimeEntity {
     @JoinColumn(nullable = false, name = "user_id")
     private User user;
 
-    public void update(String content, String country, String region, String objectKey) {
+    public void update(String content, String location, String objectKey) {
         this.content = content;
-        this.country = country;
-        this.region = region;
+        this.location = location;
         this.objectKey = objectKey;
     }
 }

--- a/src/main/java/com/example/bugle_be/domain/post/domain/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/example/bugle_be/domain/post/domain/repository/PostRepositoryCustomImpl.java
@@ -31,8 +31,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
                     post.id,
                     post.user.accountId,
                     post.user.profileImageObjectKey,
-                    post.country,
-                    post.region,
+                    post.location,
                     post.objectKey,
                     post.content
                 )
@@ -58,8 +57,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
 
         BooleanExpression condition = switch (type) {
             case CONTENT -> post.content.containsIgnoreCase(keyword);
-            case LOCATION -> post.country.containsIgnoreCase(keyword)
-                .or(post.region.containsIgnoreCase(keyword));
+            case LOCATION -> post.location.containsIgnoreCase(keyword);
         };
 
         return queryFactory
@@ -81,8 +79,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
     public Long countByTypeAndKeywordContaining(SearchType type, String keyword) {
         BooleanExpression condition = switch (type) {
             case CONTENT -> post.content.containsIgnoreCase(keyword);
-            case LOCATION -> post.country.containsIgnoreCase(keyword)
-                .or(post.region.containsIgnoreCase(keyword));
+            case LOCATION -> post.location.containsIgnoreCase(keyword);
         };
 
         return queryFactory

--- a/src/main/java/com/example/bugle_be/domain/post/presentation/dto/request/PostRequest.java
+++ b/src/main/java/com/example/bugle_be/domain/post/presentation/dto/request/PostRequest.java
@@ -4,15 +4,12 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record PostRequest(
-    @NotBlank
+    @NotBlank(message = "내용은 필수 입력값입니다.")
     @Size(max = 300, message = "내용은 300자 이내로 작성해주세요.")
     String content,
 
-    @Size(max = 20, message = "나라는 20자 이내로 작성해주세요.")
-    String country,
-
-    @Size(max = 20, message = "지역은 20자 이내로 작성해주세요.")
-    String region,
+    @Size(max = 150, message = "위치는 150자 이내로 작성해주세요.")
+    String location,
 
     @NotBlank
     String objectKey

--- a/src/main/java/com/example/bugle_be/domain/post/presentation/dto/response/PostsResponse.java
+++ b/src/main/java/com/example/bugle_be/domain/post/presentation/dto/response/PostsResponse.java
@@ -11,8 +11,7 @@ public record PostsResponse(
         Long id,
         String accountId,
         String profileImageObjectKey,
-        String country,
-        String region,
+        String location,
         String objectKey,
         String content
     ) {

--- a/src/main/java/com/example/bugle_be/domain/post/service/CreatePostService.java
+++ b/src/main/java/com/example/bugle_be/domain/post/service/CreatePostService.java
@@ -23,8 +23,7 @@ public class CreatePostService {
         postRepository.save(
             Post.builder()
                 .content(request.content())
-                .country(request.country())
-                .region(request.region())
+                .location(request.location())
                 .objectKey(request.objectKey())
                 .user(user)
                 .build()

--- a/src/main/java/com/example/bugle_be/domain/post/service/UpdatePostService.java
+++ b/src/main/java/com/example/bugle_be/domain/post/service/UpdatePostService.java
@@ -28,8 +28,7 @@ public class UpdatePostService {
 
         post.update(
             request.content(),
-            request.country(),
-            request.region(),
+            request.location(),
             request.objectKey()
         );
     }

--- a/src/main/resources/db/migration/V14__alter_post_location_column.sql
+++ b/src/main/resources/db/migration/V14__alter_post_location_column.sql
@@ -1,0 +1,6 @@
+ALTER TABLE tbl_post
+    ADD COLUMN location VARCHAR(150) NULL;
+
+ALTER TABLE tbl_post
+    DROP COLUMN country,
+    DROP COLUMN region;


### PR DESCRIPTION
## 📌 관련 이슈

> 관련된 이슈 번호를 연결해주세요  
- #102 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **변경 사항**
  * 위치 정보 입력 방식 변경: 국가와 지역 두 개 필드에서 통합된 단일 위치 필드로 업데이트되었습니다.
  * 위치 필드 최대 길이가 150자로 제한됩니다.
  * API 응답 형식이 업데이트되어 위치 정보가 단일 필드로 반환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->