### PR TITLE
(#107) 🔀 :: Elasticsearch 동기화 실패 대응을 위한 Retry + Redis DLQ 구조 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,9 @@ dependencies {
 
     // elasticsearch
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
+    // retry
+    implementation 'org.springframework.retry:spring-retry'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/bugle_be/global/config/AsyncConfig.java
+++ b/src/main/java/com/example/bugle_be/global/config/AsyncConfig.java
@@ -17,6 +17,24 @@ import java.util.concurrent.ThreadPoolExecutor;
 @Configuration
 public class AsyncConfig implements AsyncConfigurer {
 
+    @Bean(name = "defaultAsyncExecutor")
+    public ThreadPoolTaskExecutor defaultAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("default-async-");
+
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(60);
+
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+
+        executor.initialize();
+        return executor;
+    }
+
     @Bean(name = "elasticsearchAsyncExecutor")
     public ThreadPoolTaskExecutor elasticsearchAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
@@ -55,7 +73,7 @@ public class AsyncConfig implements AsyncConfigurer {
 
     @Override
     public Executor getAsyncExecutor() {
-        return mailAsyncExecutor();
+        return defaultAsyncExecutor();
     }
 
     @Override

--- a/src/main/java/com/example/bugle_be/global/config/SchedulingConfig.java
+++ b/src/main/java/com/example/bugle_be/global/config/SchedulingConfig.java
@@ -1,0 +1,10 @@
+package com.example.bugle_be.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@Configuration
+public class SchedulingConfig {
+}
+

--- a/src/main/java/com/example/bugle_be/infra/elasticsearch/dlq/DlqConstants.java
+++ b/src/main/java/com/example/bugle_be/infra/elasticsearch/dlq/DlqConstants.java
@@ -1,0 +1,22 @@
+package com.example.bugle_be.infra.elasticsearch.dlq;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class DlqConstants {
+
+    // Redis DLQ 키
+    public static final String POST_DLQ_KEY = "es:dlq:post";
+    public static final String USER_DLQ_KEY = "es:dlq:user";
+
+    // DLQ 스케줄러 사이클 기준 최대 재처리 횟수 (30분 간격)
+    public static final int MAX_DLQ_RETRY_COUNT = 3;
+
+    // Listener 즉시 재시도 횟수 (5s → 30s → 120s)
+    public static final int MAX_RETRY_ATTEMPTS = 3;
+    public static final long RETRY_INITIAL_INTERVAL = 5_000L;
+    public static final long RETRY_MAX_INTERVAL = 120_000L;
+    public static final double RETRY_MULTIPLIER = 6.0;
+}
+

--- a/src/main/java/com/example/bugle_be/infra/elasticsearch/dlq/DlqEntry.java
+++ b/src/main/java/com/example/bugle_be/infra/elasticsearch/dlq/DlqEntry.java
@@ -1,0 +1,23 @@
+package com.example.bugle_be.infra.elasticsearch.dlq;
+
+public record DlqEntry(
+    DomainType domainType,
+    String payload,
+    int retryCount
+) {
+    public enum DomainType {
+        POST, USER
+    }
+
+    public static DlqEntry of(DomainType domainType, String payload) {
+        return new DlqEntry(domainType, payload, 0);
+    }
+
+    public DlqEntry incrementRetryCount() {
+        return new DlqEntry(domainType, payload, retryCount + 1);
+    }
+
+    public boolean isExhausted() {
+        return retryCount >= DlqConstants.MAX_DLQ_RETRY_COUNT;
+    }
+}

--- a/src/main/java/com/example/bugle_be/infra/elasticsearch/dlq/ElasticsearchDlqScheduler.java
+++ b/src/main/java/com/example/bugle_be/infra/elasticsearch/dlq/ElasticsearchDlqScheduler.java
@@ -1,0 +1,83 @@
+package com.example.bugle_be.infra.elasticsearch.dlq;
+
+import com.example.bugle_be.infra.elasticsearch.event.PostIndexEvent;
+import com.example.bugle_be.infra.elasticsearch.event.UserIndexEvent;
+import com.example.bugle_be.infra.elasticsearch.post.service.DeletePostIndexService;
+import com.example.bugle_be.infra.elasticsearch.post.service.SavePostIndexService;
+import com.example.bugle_be.infra.elasticsearch.user.service.CreateUserIndexService;
+import com.example.bugle_be.infra.elasticsearch.user.service.DeleteUserIndexService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ElasticsearchDlqScheduler {
+
+    private final ElasticsearchDlqService dlqService;
+    private final SavePostIndexService savePostIndexService;
+    private final DeletePostIndexService deletePostIndexService;
+    private final CreateUserIndexService createUserIndexService;
+    private final DeleteUserIndexService deleteUserIndexService;
+    private final RetryTemplate elasticsearchRetryTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Scheduled(fixedDelay = 1_800_000)
+    public void retryDlq() {
+        processEntries(DlqConstants.POST_DLQ_KEY);
+        processEntries(DlqConstants.USER_DLQ_KEY);
+    }
+
+    private void processEntries(String key) {
+        Long size = dlqService.size(key);
+        if (size == null || size == 0) return;
+
+        for (int i = 0; i < size; i++) {
+            DlqEntry entry = dlqService.dequeue(key);
+            if (entry == null) break;
+
+            if (entry.isExhausted()) {
+                log.error("[ES DLQ 재처리 포기] 최대 재시도 횟수 초과. domainType={}, retryCount={}, payload={}",
+                    entry.domainType(), entry.retryCount(), entry.payload());
+                continue;
+            }
+
+            try {
+                processEvent(entry);
+            } catch (Exception e) {
+                log.error("[ES DLQ 재처리 최종 실패] domainType={}, retryCount={}, payload={}",
+                    entry.domainType(), entry.retryCount(), entry.payload(), e);
+                dlqService.requeue(key, entry);
+            }
+        }
+    }
+
+    private void processEvent(DlqEntry entry) throws Exception {
+        switch (entry.domainType()) {
+            case POST -> {
+                PostIndexEvent event = objectMapper.readValue(entry.payload(), PostIndexEvent.class);
+                elasticsearchRetryTemplate.execute(ctx -> {
+                    switch (event.action()) {
+                        case CREATE, UPDATE -> savePostIndexService.execute(event);
+                        case DELETE -> deletePostIndexService.execute(event);
+                    }
+                    return null;
+                });
+            }
+            case USER -> {
+                UserIndexEvent event = objectMapper.readValue(entry.payload(), UserIndexEvent.class);
+                elasticsearchRetryTemplate.execute(ctx -> {
+                    switch (event.action()) {
+                        case CREATE -> createUserIndexService.execute(event);
+                        case DELETE -> deleteUserIndexService.execute(event);
+                    }
+                    return null;
+                });
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/bugle_be/infra/elasticsearch/dlq/ElasticsearchDlqService.java
+++ b/src/main/java/com/example/bugle_be/infra/elasticsearch/dlq/ElasticsearchDlqService.java
@@ -1,0 +1,51 @@
+package com.example.bugle_be.infra.elasticsearch.dlq;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ElasticsearchDlqService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+
+    public void enqueue(String key, DlqEntry.DomainType domainType, Object event) {
+        try {
+            String payload = objectMapper.writeValueAsString(event);
+            DlqEntry entry = DlqEntry.of(domainType, payload);
+            String json = objectMapper.writeValueAsString(entry);
+            redisTemplate.opsForList().rightPush(key, json);
+        } catch (JsonProcessingException ignored) {
+        }
+    }
+
+    public void requeue(String key, DlqEntry entry) {
+        try {
+            DlqEntry incremented = entry.incrementRetryCount();
+            String json = objectMapper.writeValueAsString(incremented);
+            redisTemplate.opsForList().rightPush(key, json);
+        } catch (JsonProcessingException ignored) {
+        }
+    }
+
+    public DlqEntry dequeue(String key) {
+        try {
+            String json = redisTemplate.opsForList().leftPop(key);
+            if (json == null) return null;
+            return objectMapper.readValue(json, DlqEntry.class);
+        } catch (JsonProcessingException ignored) {
+            return null;
+        }
+    }
+
+    public Long size(String key) {
+        return redisTemplate.opsForList().size(key);
+    }
+}
+
+

--- a/src/main/java/com/example/bugle_be/infra/elasticsearch/dlq/ElasticsearchRetryConfig.java
+++ b/src/main/java/com/example/bugle_be/infra/elasticsearch/dlq/ElasticsearchRetryConfig.java
@@ -1,0 +1,29 @@
+package com.example.bugle_be.infra.elasticsearch.dlq;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+
+@Configuration
+public class ElasticsearchRetryConfig {
+
+    @Bean(name = "elasticsearchRetryTemplate")
+    public RetryTemplate elasticsearchRetryTemplate() {
+        RetryTemplate retryTemplate = new RetryTemplate();
+
+        ExponentialBackOffPolicy backOffPolicy = new ExponentialBackOffPolicy();
+        backOffPolicy.setInitialInterval(DlqConstants.RETRY_INITIAL_INTERVAL);
+        backOffPolicy.setMaxInterval(DlqConstants.RETRY_MAX_INTERVAL);
+        backOffPolicy.setMultiplier(DlqConstants.RETRY_MULTIPLIER);
+
+        SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy();
+        retryPolicy.setMaxAttempts(DlqConstants.MAX_RETRY_ATTEMPTS);
+
+        retryTemplate.setBackOffPolicy(backOffPolicy);
+        retryTemplate.setRetryPolicy(retryPolicy);
+
+        return retryTemplate;
+    }
+}

--- a/src/main/java/com/example/bugle_be/infra/elasticsearch/event/PostIndexEventListener.java
+++ b/src/main/java/com/example/bugle_be/infra/elasticsearch/event/PostIndexEventListener.java
@@ -1,32 +1,39 @@
 package com.example.bugle_be.infra.elasticsearch.event;
 
+import com.example.bugle_be.infra.elasticsearch.dlq.DlqConstants;
+import com.example.bugle_be.infra.elasticsearch.dlq.DlqEntry;
+import com.example.bugle_be.infra.elasticsearch.dlq.ElasticsearchDlqService;
 import com.example.bugle_be.infra.elasticsearch.post.service.DeletePostIndexService;
 import com.example.bugle_be.infra.elasticsearch.post.service.SavePostIndexService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class PostIndexEventListener {
 
     private final SavePostIndexService savePostIndexService;
     private final DeletePostIndexService deletePostIndexService;
+    private final ElasticsearchDlqService dlqService;
+    private final RetryTemplate elasticsearchRetryTemplate;
 
     @Async("elasticsearchAsyncExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(PostIndexEvent event) {
         try {
-            switch (event.action()) {
-                case CREATE, UPDATE -> savePostIndexService.execute(event);
-                case DELETE -> deletePostIndexService.execute(event);
-            }
+            elasticsearchRetryTemplate.execute(ctx -> {
+                switch (event.action()) {
+                    case CREATE, UPDATE -> savePostIndexService.execute(event);
+                    case DELETE -> deletePostIndexService.execute(event);
+                }
+                return null;
+            });
         } catch (Exception e) {
-            log.error("[ES 인덱싱 실패] action={}, postId={}", event.action(), event.postId(), e);
+            dlqService.enqueue(DlqConstants.POST_DLQ_KEY, DlqEntry.DomainType.POST, event);
         }
     }
 }

--- a/src/main/java/com/example/bugle_be/infra/elasticsearch/event/UserIndexEventListener.java
+++ b/src/main/java/com/example/bugle_be/infra/elasticsearch/event/UserIndexEventListener.java
@@ -1,32 +1,39 @@
 package com.example.bugle_be.infra.elasticsearch.event;
 
+import com.example.bugle_be.infra.elasticsearch.dlq.DlqConstants;
+import com.example.bugle_be.infra.elasticsearch.dlq.DlqEntry;
+import com.example.bugle_be.infra.elasticsearch.dlq.ElasticsearchDlqService;
 import com.example.bugle_be.infra.elasticsearch.user.service.CreateUserIndexService;
 import com.example.bugle_be.infra.elasticsearch.user.service.DeleteUserIndexService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class UserIndexEventListener {
 
     private final CreateUserIndexService createUserIndexService;
     private final DeleteUserIndexService deleteUserIndexService;
+    private final ElasticsearchDlqService dlqService;
+    private final RetryTemplate elasticsearchRetryTemplate;
 
     @Async("elasticsearchAsyncExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(UserIndexEvent event) {
         try {
-            switch (event.action()) {
-                case CREATE -> createUserIndexService.execute(event);
-                case DELETE -> deleteUserIndexService.execute(event);
-            }
+            elasticsearchRetryTemplate.execute(ctx -> {
+                switch (event.action()) {
+                    case CREATE -> createUserIndexService.execute(event);
+                    case DELETE -> deleteUserIndexService.execute(event);
+                }
+                return null;
+            });
         } catch (Exception e) {
-            log.error("[ES 인덱싱 실패] action={}, userId={}", event.action(), event.userId(), e);
+            dlqService.enqueue(DlqConstants.USER_DLQ_KEY, DlqEntry.DomainType.USER, event);
         }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
> 관련된 이슈 번호를 연결해주세요  
- #107


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Elasticsearch 작업 실패 시 자동 재시도 및 복구 메커니즘 추가
  * 실패한 인덱싱 작업을 추적하고 주기적으로 재처리하는 Dead Letter Queue 시스템 구현

* **개선사항**
  * 비동기 작업 처리의 안정성 및 성능 향상
  * 스케줄링 기능 활성화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->