### PR TITLE
(#109) 🔀 :: 마이페이지 수정 및 Elasticsearch 유저 데이터 동기화

### DIFF
--- a/src/main/java/com/example/bugle_be/domain/user/domain/User.java
+++ b/src/main/java/com/example/bugle_be/domain/user/domain/User.java
@@ -48,6 +48,12 @@ public class User extends BaseTimeEntity {
         this.deviceToken = null;
     }
 
+    public void update(String accountId, String userName, String profileImageObjectKey) {
+        this.accountId = accountId;
+        this.userName = userName;
+        this.profileImageObjectKey = profileImageObjectKey;
+    }
+
     public boolean isCustomProfileImage() {
         return !this.profileImageObjectKey.equals(ImageProperty.DEFAULT_USER_PROFILE_IMAGE);
     }

--- a/src/main/java/com/example/bugle_be/domain/user/exception/AccountIdAlreadyExists.java
+++ b/src/main/java/com/example/bugle_be/domain/user/exception/AccountIdAlreadyExists.java
@@ -1,0 +1,13 @@
+package com.example.bugle_be.domain.user.exception;
+
+import com.example.bugle_be.domain.user.exception.error.UserErrorCode;
+import com.example.bugle_be.global.error.exception.BugleException;
+
+public class AccountIdAlreadyExists extends BugleException {
+
+    public static final BugleException EXCEPTION = new AccountIdAlreadyExists();
+
+    private AccountIdAlreadyExists() {
+        super(UserErrorCode.ACCOUNT_ID_ALREADY_EXISTS);
+    }
+}

--- a/src/main/java/com/example/bugle_be/domain/user/exception/error/UserErrorCode.java
+++ b/src/main/java/com/example/bugle_be/domain/user/exception/error/UserErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum UserErrorCode implements ErrorProperty {
 
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "User Not Found");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "User Not Found"),
+    ACCOUNT_ID_ALREADY_EXISTS(HttpStatus.CONFLICT, "Account ID Already Exists");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/example/bugle_be/domain/user/presentation/UserController.java
+++ b/src/main/java/com/example/bugle_be/domain/user/presentation/UserController.java
@@ -1,12 +1,19 @@
 package com.example.bugle_be.domain.user.presentation;
 
+import com.example.bugle_be.domain.user.presentation.dto.request.UserInfoRequest;
 import com.example.bugle_be.domain.user.presentation.dto.response.UserProfileResponse;
 import com.example.bugle_be.domain.user.service.QueryMyProfileService;
 import com.example.bugle_be.domain.user.service.QueryUserProfileService;
+import com.example.bugle_be.domain.user.service.UpdateUserInfoService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -16,6 +23,7 @@ public class UserController {
 
     private final QueryMyProfileService queryMyProfileService;
     private final QueryUserProfileService queryUserProfileService;
+    private final UpdateUserInfoService updateUserInfoService;
 
     @GetMapping("/me")
     public UserProfileResponse getMyProfile() {
@@ -25,5 +33,11 @@ public class UserController {
     @GetMapping("/{user-id}")
     public UserProfileResponse getUserProfile(@PathVariable(name = "user-id") Long userId) {
         return queryUserProfileService.execute(userId);
+    }
+
+    @PatchMapping("/me")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void updateUserInfo(@RequestBody @Valid UserInfoRequest request) {
+        updateUserInfoService.execute(request);
     }
 }

--- a/src/main/java/com/example/bugle_be/domain/user/presentation/dto/request/UserInfoRequest.java
+++ b/src/main/java/com/example/bugle_be/domain/user/presentation/dto/request/UserInfoRequest.java
@@ -20,6 +20,7 @@ public record UserInfoRequest(
     @Size(max = 20, message = MessageProperty.USERNAME_SIZE)
     String userName,
 
+    @Size(max = 255, message = MessageProperty.PROFILE_IMAGE_OBJECT_KEY_SIZE)
     String profileImageObjectKey
 ) {
 }

--- a/src/main/java/com/example/bugle_be/domain/user/presentation/dto/request/UserInfoRequest.java
+++ b/src/main/java/com/example/bugle_be/domain/user/presentation/dto/request/UserInfoRequest.java
@@ -1,0 +1,33 @@
+package com.example.bugle_be.domain.user.presentation.dto.request;
+
+import com.example.bugle_be.domain.user.domain.User;
+import com.example.bugle_be.global.util.MessageProperty;
+import com.example.bugle_be.global.util.RegexProperty;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UserInfoRequest(
+    @Pattern(
+        regexp = RegexProperty.ACCOUNT_ID,
+        message = MessageProperty.ACCOUNT_ID_PATTERN
+    )
+    @Size(min = 4, max = 20, message = MessageProperty.ACCOUNT_ID_SIZE)
+    String accountId,
+
+    @Pattern(
+        regexp = RegexProperty.USERNAME,
+        message = MessageProperty.USERNAME_PATTERN
+    )
+    @Size(max = 20, message = MessageProperty.USERNAME_SIZE)
+    String userName,
+
+    String profileImageObjectKey
+) {
+    public UserInfoRequest resolve(User user) {
+        return new UserInfoRequest(
+            accountId != null ? accountId : user.getAccountId(),
+            userName != null ? userName : user.getUserName(),
+            profileImageObjectKey != null ? profileImageObjectKey : user.getProfileImageObjectKey()
+        );
+    }
+}

--- a/src/main/java/com/example/bugle_be/domain/user/presentation/dto/request/UserInfoRequest.java
+++ b/src/main/java/com/example/bugle_be/domain/user/presentation/dto/request/UserInfoRequest.java
@@ -1,6 +1,5 @@
 package com.example.bugle_be.domain.user.presentation.dto.request;
 
-import com.example.bugle_be.domain.user.domain.User;
 import com.example.bugle_be.global.util.MessageProperty;
 import com.example.bugle_be.global.util.RegexProperty;
 import jakarta.validation.constraints.Pattern;
@@ -23,11 +22,4 @@ public record UserInfoRequest(
 
     String profileImageObjectKey
 ) {
-    public UserInfoRequest resolve(User user) {
-        return new UserInfoRequest(
-            accountId != null ? accountId : user.getAccountId(),
-            userName != null ? userName : user.getUserName(),
-            profileImageObjectKey != null ? profileImageObjectKey : user.getProfileImageObjectKey()
-        );
-    }
 }

--- a/src/main/java/com/example/bugle_be/domain/user/service/UpdateUserInfoService.java
+++ b/src/main/java/com/example/bugle_be/domain/user/service/UpdateUserInfoService.java
@@ -1,0 +1,36 @@
+package com.example.bugle_be.domain.user.service;
+
+import com.example.bugle_be.domain.user.domain.User;
+import com.example.bugle_be.domain.user.domain.repository.UserRepository;
+import com.example.bugle_be.domain.user.exception.AccountIdAlreadyExists;
+import com.example.bugle_be.domain.user.facade.UserFacade;
+import com.example.bugle_be.domain.user.presentation.dto.request.UserInfoRequest;
+import com.example.bugle_be.infra.elasticsearch.event.UserIndexEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateUserInfoService {
+
+    private final UserFacade userFacade;
+    private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public void execute(UserInfoRequest request) {
+        User user = userFacade.getCurrentUser();
+        UserInfoRequest resolved = request.resolve(user);
+
+        if (!user.getAccountId().equals(resolved.accountId())
+                && userRepository.existsByAccountId(resolved.accountId())) {
+            throw AccountIdAlreadyExists.EXCEPTION;
+        }
+
+        user.update(resolved.accountId(), resolved.userName(), resolved.profileImageObjectKey());
+
+        eventPublisher.publishEvent(UserIndexEvent.update(user));
+    }
+}

--- a/src/main/java/com/example/bugle_be/domain/user/service/UpdateUserInfoService.java
+++ b/src/main/java/com/example/bugle_be/domain/user/service/UpdateUserInfoService.java
@@ -22,7 +22,7 @@ public class UpdateUserInfoService {
     @Transactional
     public void execute(UserInfoRequest request) {
         User user = userFacade.getCurrentUser();
-        UserInfoRequest resolved = request.resolve(user);
+        UserInfoRequest resolved = resolve(request, user);
 
         if (!user.getAccountId().equals(resolved.accountId())
                 && userRepository.existsByAccountId(resolved.accountId())) {
@@ -32,5 +32,13 @@ public class UpdateUserInfoService {
         user.update(resolved.accountId(), resolved.userName(), resolved.profileImageObjectKey());
 
         eventPublisher.publishEvent(UserIndexEvent.update(user));
+    }
+
+    private UserInfoRequest resolve(UserInfoRequest request, User user) {
+        return new UserInfoRequest(
+            request.accountId() != null ? request.accountId() : user.getAccountId(),
+            request.userName() != null ? request.userName() : user.getUserName(),
+            request.profileImageObjectKey() != null ? request.profileImageObjectKey() : user.getProfileImageObjectKey()
+        );
     }
 }

--- a/src/main/java/com/example/bugle_be/global/util/MessageProperty.java
+++ b/src/main/java/com/example/bugle_be/global/util/MessageProperty.java
@@ -25,6 +25,9 @@ public class MessageProperty {
     public static final String USERNAME_PATTERN = "이름은 한글 또는 영어 대소문자만 입력 가능합니다.";
     public static final String USERNAME_SIZE = "이름은 20자 이내로 입력해주세요.";
 
+    // profileImageObjectKey
+    public static final String PROFILE_IMAGE_OBJECT_KEY_SIZE = "프로필 이미지 키는 255자 이내로 입력해주세요.";
+
     // token
     public static final String TOKEN_NOT_BLANK = "인증 토큰은 필수 입력 항목입니다.";
     public static final String DEVICE_TOKEN_NOT_BLANK = "디바이스 토큰은 필수 입력 항목입니다.";

--- a/src/main/java/com/example/bugle_be/infra/elasticsearch/event/UserIndexEvent.java
+++ b/src/main/java/com/example/bugle_be/infra/elasticsearch/event/UserIndexEvent.java
@@ -13,6 +13,10 @@ public record UserIndexEvent(
         return new UserIndexEvent(user.getId(), user.getAccountId(), user.getUserName(), user.getProfileImageObjectKey(), IndexAction.CREATE);
     }
 
+    public static UserIndexEvent update(User user) {
+        return new UserIndexEvent(user.getId(), user.getAccountId(), user.getUserName(), user.getProfileImageObjectKey(), IndexAction.UPDATE);
+    }
+
     public static UserIndexEvent delete(Long userId) {
         return new UserIndexEvent(userId, null, null, null, IndexAction.DELETE);
     }

--- a/src/main/java/com/example/bugle_be/infra/elasticsearch/event/UserIndexEventListener.java
+++ b/src/main/java/com/example/bugle_be/infra/elasticsearch/event/UserIndexEventListener.java
@@ -27,7 +27,7 @@ public class UserIndexEventListener {
         try {
             elasticsearchRetryTemplate.execute(ctx -> {
                 switch (event.action()) {
-                    case CREATE -> createUserIndexService.execute(event);
+                    case CREATE, UPDATE -> createUserIndexService.execute(event);
                     case DELETE -> deleteUserIndexService.execute(event);
                 }
                 return null;


### PR DESCRIPTION
## 📌 관련 이슈

> 관련된 이슈 번호를 연결해주세요  
- #109 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * PATCH /me 엔드포인트 추가: 계정 ID, 사용자명, 프로필 이미지 수정(유효성 검사 적용, 성공 시 204 No Content).
  * 수정 요청에 accountId/userName/profileImage 필드 추가 및 관련 입력 제약(형식·길이) 적용.
  * 계정 ID 중복 시 충돌 오류 반환.

* **잡무(Chores)**
  * 프로필 변경 시 검색 색인 갱신을 위한 색인 업데이트 이벤트 발행 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->